### PR TITLE
Added section in setup.py to automatically register irods_fsspec backend

### DIFF
--- a/irods_fsspec/__init__.py
+++ b/irods_fsspec/__init__.py
@@ -260,7 +260,7 @@ class IRODSFileSystem(AbstractFileSystem):
 
     def cat_file(self, path, start=None, end=None, **kwargs):
         data_obj_size = self.session.data_objects.get(path).size
-        print(f"irods-fsspec : cat file {path} of size {data_obj_size}")
+        log.debug(f"irods-fsspec : cat file {path} of size {data_obj_size}")
 
         with self.open(path, "rb", block_size=0, **kwargs) as f:
             return f.read(data_obj_size)

--- a/irods_fsspec/__init__.py
+++ b/irods_fsspec/__init__.py
@@ -258,5 +258,12 @@ class IRODSFileSystem(AbstractFileSystem):
         else:
             proxy_obj.copy(path1, path2)
 
+    def cat_file(self, path, start=None, end=None, **kwargs):
+        data_obj_size = self.session.data_objects.get(path).size
+        print(f"irods-fsspec : cat file {path} of size {data_obj_size}")
+
+        with self.open(path, "rb", block_size=0, **kwargs) as f:
+            return f.read(data_obj_size)
+
 def register():
     register_implementation('irods', IRODSFileSystem)

--- a/setup.py
+++ b/setup.py
@@ -35,3 +35,11 @@ setup(
         'Bug Reports': f'https://github.com/magao-x/{PROJECT}/issues',
     },
 )
+
+setuptools.setup(
+        entry_points={
+                'fsspec.specs': [
+                        'irods=irods_fsspec.IRODSFileSystem',
+                    ],
+            }
+)


### PR DESCRIPTION
Hi ! First, thank you for this fsspec backend which I needed a lot !
It works well from what I tried.
I also wanted to integrate data access directly from an intake catalog with the intake-xarray module, so I had to add a few lines in the setup.py file in order for irods_fsspec to automatically register itself.

Followed this : https://filesystem-spec.readthedocs.io/en/latest/developer.html#implementing-a-backend
